### PR TITLE
 Allow empty namespace to monitor any namespace

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -94,7 +94,7 @@ type DefaultExtensionManager struct {
 // ManagerOptions represent the Runtime manager options
 type ManagerOptions struct {
 
-	// Namespace is the namespace where the Manager is operating
+	// Namespace is the namespace where pods will trigger the extension. Use empty to trigger on all namespaces.
 	Namespace string
 
 	// Host is the listening host address for the Manager
@@ -319,7 +319,7 @@ func (m *DefaultExtensionManager) GenWebHookServer() {
 			Fs:                afero.NewOsFs(),
 		},
 		m.Credsgen,
-		fmt.Sprintf("%s-mutating-hook-%s", m.Options.OperatorFingerprint, m.Options.Namespace),
+		fmt.Sprintf("%s-mutating-hook", m.Options.OperatorFingerprint),
 		m.Options.SetupCertificateName,
 		m.Options.ServiceName,
 		m.Options.WebhookNamespace)
@@ -337,8 +337,10 @@ func (m *DefaultExtensionManager) OperatorSetup() error {
 
 	m.GenWebHookServer()
 
-	if err := m.setOperatorNamespaceLabel(); err != nil {
-		return errors.Wrap(err, "setting the operator namespace label")
+	if m.Options.Namespace != "" {
+		if err := m.setOperatorNamespaceLabel(); err != nil {
+			return errors.Wrap(err, "setting the operator namespace label")
+		}
 	}
 
 	if *m.Options.SetupCertificate {

--- a/manager_test.go
+++ b/manager_test.go
@@ -160,6 +160,17 @@ var _ = Describe("Extension Manager", func() {
 
 	})
 
+	It("doesn't set the operator namespace label if no namespace if defined", func() {
+		eiriniManager.Options.Namespace = ""
+		err := eiriniManager.OperatorSetup()
+		Expect(err).ToNot(HaveOccurred())
+
+		err = eiriniManager.LoadExtensions()
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(client.UpdateCallCount()).To(Equal(0))
+	})
+
 	Context("if there is a persisted cert secret already", func() {
 		BeforeEach(func() {
 			secret := &unstructured.Unstructured{
@@ -199,7 +210,7 @@ var _ = Describe("Extension Manager", func() {
 		It("generates the webhook configuration", func() {
 			client.CreateCalls(func(context context.Context, object runtime.Object, _ ...crc.CreateOption) error {
 				config := object.(*admissionregistrationv1beta1.MutatingWebhookConfiguration)
-				Expect(config.Name).To(Equal("eirini-x-mutating-hook-" + config.Namespace))
+				Expect(config.Name).To(Equal("eirini-x-mutating-hook"))
 				Expect(len(config.Webhooks)).To(Equal(1))
 
 				wh := config.Webhooks[0]

--- a/testing/catalog.go
+++ b/testing/catalog.go
@@ -74,7 +74,7 @@ func (c *Catalog) IntegrationManagerFiltered(b bool, n string) eirinix.Manager {
 			Port:             c.ServicePort,
 			KubeConfig:       os.Getenv("KUBECONFIG"),
 			ServiceName:      "eirinix",
-			WebhookNamespace: n,
+			WebhookNamespace: "default",
 			FilterEiriniApps: &b,
 		})
 }

--- a/testing/utils.go
+++ b/testing/utils.go
@@ -49,10 +49,7 @@ type Pod struct {
 }
 
 func (p *Pod) IsRunning() bool {
-	if p.PodStatus.Phase == "Running" {
-		return true
-	}
-	return false
+	return p.PodStatus.Phase == "Running"
 }
 
 func KubePodStatus(podname, n string) (*Pod, error) {

--- a/webhook.go
+++ b/webhook.go
@@ -149,7 +149,9 @@ func (w *DefaultMutatingWebhook) RegisterAdmissionWebHook(server *webhook.Server
 	w.Path = fmt.Sprintf("/%s", opts.ID)
 
 	w.Name = fmt.Sprintf("%s.%s.org", opts.ID, opts.ManagerOptions.OperatorFingerprint)
-	w.NamespaceSelector = w.getNamespaceSelector(opts)
+	if opts.ManagerOptions.Namespace != "" {
+		w.NamespaceSelector = w.getNamespaceSelector(opts)
+	}
 	w.Webhook = &admission.Webhook{
 		Handler: w,
 	}


### PR DESCRIPTION
and handle permissions errors when creating the webhook. Also create the
webhook secret in the same namespace where the webhook is deployed,
rather than the monitored namespace.

[Fixes #45]

Signed-off-by: Kieron Browne kbrowne@pivotal.io