### PR TITLE
Allow setting the service port for the webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ func main() {
                 // KubeConfig can be ommitted for in-cluster connections
                 KubeConfig: kubeConfig,
                 ServiceName: "listening-extension",
+                Port: 8889,
                 // WebhookNamespace, when ServiceName is supplied, a WebhookNamespace is required to indicate in which namespace the webhook service runs on
                 WebhookNamespace: "cf",
         })
@@ -98,9 +99,8 @@ func main() {
 
 The host will be the listening ip, and the service name refer to the kubernetes service. You need also to specify `WebhookNamespace` which is the namespace where the extension pod is running.
 
-Note that you cannot setup a port, and default one is used (443) for specifying a service. You must use 443 as external port in the service, and refer as the internal one to the one specified with `Port`.
-This is a limitation and the `Port` option will refer to the local listener until there will be a kubernetes client api bump of the EiriniX dependencies (cf-operator).
-
+If you specify `Port` that will be both the port on which the webhook service will listen and the internal port (the container port). If you don't specify it, the default is `443`
+(https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#service-reference).
 
 ### Split Extension registration into two binaries
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -334,7 +334,7 @@ func deleteNamespace(name string) {
 func EventuallyExtensionShouldBeRegistered() {
 	EventuallyWithOffset(1, func() (string, error) {
 		return catalog.Kubectl([]string{}, "get", "mutatingwebhookconfiguration")
-	}, time.Duration(60*time.Second), time.Duration(5*time.Second)).ShouldNot(ContainSubstring("No resources found in default namespace"))
+	}, time.Duration(60*time.Second), time.Duration(5*time.Second)).ShouldNot(ContainSubstring("No resources found"))
 }
 
 func EventuallyExtensionShouldBe(name string) {
@@ -345,8 +345,8 @@ func EventuallyExtensionShouldBe(name string) {
 
 func ExtensionShouldBeUnregistered() {
 	str, err := catalog.Kubectl([]string{}, "get", "mutatingwebhookconfiguration")
+	ExpectWithOffset(1, str).To(ContainSubstring("No resources found"))
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
-	ExpectWithOffset(1, str).To(ContainSubstring("No resources found in default namespace"))
 }
 
 func AppShouldHaveSingleContainerWithEnv(app *catalog.EiriniApp, contents []catalog.ContainerEnv) {

--- a/manager_test.go
+++ b/manager_test.go
@@ -334,7 +334,7 @@ var _ = Describe("Extension Manager", func() {
 
 	Context("Extensions with services", func() {
 		It("doesn't fail", func() {
-			Expect(eiriniServiceManager.Options.Port).To(Equal(int32(0)))
+			Expect(eiriniServiceManager.Options.Port).To(Equal(int32(8001)))
 			eiriniServiceManager.AddExtension(eirinixcatalog.SimpleExtension())
 			err := eiriniServiceManager.OperatorSetup()
 			Expect(err).ToNot(HaveOccurred())

--- a/testing/catalog.go
+++ b/testing/catalog.go
@@ -104,8 +104,7 @@ metadata:
 spec:
   ports:
   - protocol: TCP
-    port: 443
-    targetPort: ` + strconv.Itoa(int(c.ServicePort)) + `
+    port: ` + strconv.Itoa(int(c.ServicePort)) + `
 ---
 apiVersion: v1
 kind: Endpoints
@@ -252,7 +251,7 @@ func (c *Catalog) SimpleManagerService() eirinix.Manager {
 		eirinix.ManagerOptions{
 			Namespace:        "eirini",
 			Host:             "0.0.0.0",
-			Port:             0,
+			Port:             8001,
 			ServiceName:      "extension",
 			WebhookNamespace: "cf",
 		})

--- a/webhook_configuration.go
+++ b/webhook_configuration.go
@@ -184,9 +184,7 @@ func (f *WebhookConfig) GenerateAdmissionWebhook(webhooks []MutatingWebhook) []a
 					Name:      f.serviceName,
 					Namespace: f.webhookNamespace,
 					Path:      &p,
-					// FIXME:
-					// client version still doesn't support specify a port for service reference
-					//		Port:      &f.config.WebhookServerPort,
+					Port:      &f.config.WebhookServerPort,
 				},
 			}
 		} else {

--- a/webhook_configuration_test.go
+++ b/webhook_configuration_test.go
@@ -3,11 +3,11 @@ package extension_test
 import (
 	"context"
 
-	credsgen "code.cloudfoundry.org/quarks-utils/pkg/credsgen"
-	gfakes "code.cloudfoundry.org/quarks-utils/pkg/credsgen/fakes"
 	. "code.cloudfoundry.org/eirinix"
 	catalog "code.cloudfoundry.org/eirinix/testing"
 	cfakes "code.cloudfoundry.org/eirinix/testing/fakes"
+	credsgen "code.cloudfoundry.org/quarks-utils/pkg/credsgen"
+	gfakes "code.cloudfoundry.org/quarks-utils/pkg/credsgen/fakes"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
@@ -94,10 +94,12 @@ var _ = Describe("Webhook configuration implementation", func() {
 			admissions := eiriniServiceManager.WebhookConfig.GenerateAdmissionWebhook([]MutatingWebhook{w})
 			Expect(len(admissions)).To(Equal(1))
 			url := "/volume"
+			port := int32(8001)
 
 			Expect(admissions[0].ClientConfig.URL).To(BeNil())
 			Expect(admissions[0].ClientConfig.Service.Name).To(Equal("extension"))
 			Expect(admissions[0].ClientConfig.Service.Namespace).To(Equal("cf"))
+			Expect(admissions[0].ClientConfig.Service.Port).To(Equal(&port))
 			Expect(admissions[0].ClientConfig.Service.Path).To(Equal(&url))
 		})
 	})


### PR DESCRIPTION
Co-authored-by: Kieron Browne <kbrowne@pivotal.io>

It seems that after the various bumps of the kubernetes libraries, we reached a version where this is supported. 