### PR TITLE
Add support for EiriniX reconcilers

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -182,18 +182,6 @@ var _ = Describe("EiriniX", func() {
 			watcher    extension.Watcher
 		)
 
-		eventuallyReceivesEvent := func(evType watch.EventType, appName string) {
-			extension, _ := watcher.(*catalog.SimpleWatcherWithChannel)
-
-			ev := &watch.Event{}
-			EventuallyWithOffset(1, extension.Received, "5s").Should(Receive(ev))
-			ExpectWithOffset(1, ev.Type).To(Equal(evType))
-
-			pod, ok := ev.Object.(*corev1.Pod)
-			ExpectWithOffset(1, ok).To(BeTrue())
-			ExpectWithOffset(1, pod.GetName()).To(Equal(appName))
-		}
-
 		BeforeEach(func() {
 			ExtensionShouldBeUnregistered()
 
@@ -220,9 +208,9 @@ var _ = Describe("EiriniX", func() {
 
 				Expect(app.Delete()).To(Succeed())
 
-				eventuallyReceivesEvent(watch.Added, app.Name)
-				eventuallyReceivesEvent(watch.Modified, app.Name)
-				eventuallyReceivesEvent(watch.Modified, app.Name)
+				EventuallyReceivesEvent(watcher, watch.Added, app.Name)
+				EventuallyReceivesEvent(watcher, watch.Modified, app.Name)
+				EventuallyReceivesEvent(watcher, watch.Modified, app.Name)
 			})
 		})
 
@@ -249,9 +237,9 @@ var _ = Describe("EiriniX", func() {
 
 				Expect(app.Delete()).To(Succeed())
 
-				eventuallyReceivesEvent(watch.Added, app.Name)
-				eventuallyReceivesEvent(watch.Modified, app.Name)
-				eventuallyReceivesEvent(watch.Modified, app.Name)
+				EventuallyReceivesEvent(watcher, watch.Added, app.Name)
+				EventuallyReceivesEvent(watcher, watch.Modified, app.Name)
+				EventuallyReceivesEvent(watcher, watch.Modified, app.Name)
 			})
 		})
 
@@ -288,9 +276,9 @@ var _ = Describe("EiriniX", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Eventually(standardapp.IsRunning, time.Duration(60*time.Second), time.Duration(5*time.Second)).Should(BeTrue())
 
-				eventuallyReceivesEvent(watch.Added, standardapp.Name)
-				eventuallyReceivesEvent(watch.Modified, standardapp.Name)
-				eventuallyReceivesEvent(watch.Modified, standardapp.Name)
+				EventuallyReceivesEvent(watcher, watch.Added, standardapp.Name)
+				EventuallyReceivesEvent(watcher, watch.Modified, standardapp.Name)
+				EventuallyReceivesEvent(watcher, watch.Modified, standardapp.Name)
 			})
 
 			It("cannot see Eirini pods in other namespaces when namespace is set", func() {
@@ -312,9 +300,9 @@ var _ = Describe("EiriniX", func() {
 					Expect(err).ToNot(HaveOccurred())
 					Eventually(app.IsRunning, time.Duration(60*time.Second), time.Duration(5*time.Second)).Should(BeTrue())
 
-					eventuallyReceivesEvent(watch.Added, app.Name)
-					eventuallyReceivesEvent(watch.Modified, app.Name)
-					eventuallyReceivesEvent(watch.Modified, app.Name)
+					EventuallyReceivesEvent(watcher, watch.Added, app.Name)
+					EventuallyReceivesEvent(watcher, watch.Modified, app.Name)
+					EventuallyReceivesEvent(watcher, watch.Modified, app.Name)
 				})
 			})
 		})
@@ -344,6 +332,60 @@ var _ = Describe("EiriniX", func() {
 				Expect(app.Sync()).To(Succeed())
 				Expect(app.Pod.Metadata.Annotations).To(ContainElement("yes"))
 				Expect(app.Pod.Metadata.Annotations["touched"]).To(Equal("yes"))
+			})
+		})
+	})
+
+	Context("multiple extension types", func() {
+		var (
+			app *catalog.EiriniApp
+
+			resultChan chan watch.Event
+			watcher    extension.Watcher
+		)
+
+		JustBeforeEach(func() {
+			var err error
+			app, err = cat.StartEiriniApp()
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(app.IsRunning, time.Duration(60*time.Second), time.Duration(5*time.Second)).Should(BeTrue())
+		})
+
+		When("there are extension, watcher and reconcilers started from the same process", func() {
+			BeforeEach(func() {
+				resultChan = make(chan watch.Event, 3)
+				watcher = cat.SimpleWatcherWithChannel(resultChan)
+
+				Expect(cat.RegisterEiriniXService()).To(Succeed())
+
+				mgr.AddExtension(&catalog.EditImageReconciler{})
+				mgr.AddExtension(watcher)
+				mgr.AddExtension(ext)
+
+				go mgr.Start()
+
+				EventuallyExtensionShouldBeRegistered()
+			})
+
+			It("adds the annotation", func() {
+				Expect(app.Sync()).To(Succeed())
+				Eventually(func() string {
+					app.Sync()
+					return app.Pod.Spec.Containers[0].Image
+				}, "60s").Should(Equal("opensuse/leap"))
+			})
+
+			It("still adds the env var to the original app", func() {
+				AppShouldHaveSingleContainerWithEnv(app, []catalog.ContainerEnv{
+					{Name: "STICKY_MESSAGE", Value: "Eirinix is awesome!"},
+					{Name: "FAKE_APP", Value: "fake content"},
+				})
+			})
+
+			It("processes events", func() {
+				EventuallyReceivesEvent(watcher, watch.Added, app.Name)
+				EventuallyReceivesEvent(watcher, watch.Modified, app.Name)
+				EventuallyReceivesEvent(watcher, watch.Modified, app.Name)
 			})
 		})
 	})
@@ -381,4 +423,16 @@ func AppShouldHaveSingleContainerWithEnv(app *catalog.EiriniApp, contents []cata
 	ExpectWithOffset(1, app.Sync()).To(Succeed())
 	ExpectWithOffset(1, app.Pod.Spec.Containers).To(HaveLen(1))
 	ExpectWithOffset(1, app.Pod.Spec.Containers[0].Envs).To(ConsistOf(contents))
+}
+
+func EventuallyReceivesEvent(watcher extension.Watcher, evType watch.EventType, appName string) {
+	extension, _ := watcher.(*catalog.SimpleWatcherWithChannel)
+
+	ev := &watch.Event{}
+	EventuallyWithOffset(1, extension.Received, "5s").Should(Receive(ev))
+	ExpectWithOffset(1, ev.Type).To(Equal(evType))
+
+	pod, ok := ev.Object.(*corev1.Pod)
+	ExpectWithOffset(1, ok).To(BeTrue())
+	ExpectWithOffset(1, pod.GetName()).To(Equal(appName))
 }

--- a/interface.go
+++ b/interface.go
@@ -81,7 +81,7 @@ type Manager interface {
 	// AddExtension adds an Extension to the manager
 	//
 	// The manager later on, will register the Extension when Start() is being called.
-	AddExtension(e Extension)
+	AddExtension(v interface{}) error
 
 	// AddReconciler adds a Reconciler Extension to the manager
 	//

--- a/interface.go
+++ b/interface.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
@@ -39,6 +40,15 @@ type Extension interface {
 // namespace.
 type Watcher interface {
 	Handle(Manager, watch.Event)
+}
+
+// Reconciler is the Eirini Reconciler Extension interface
+//
+// An Eirini Reconciler must implement a Reconcile method which is called when
+// a new request is being created.
+type Reconciler interface {
+	Reconcile(request reconcile.Request) (reconcile.Result, error)
+	Register(Manager) error
 }
 
 // MutatingWebhook is the interface of the generated webhook

--- a/interface.go
+++ b/interface.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -82,6 +83,11 @@ type Manager interface {
 	// The manager later on, will register the Extension when Start() is being called.
 	AddExtension(e Extension)
 
+	// AddReconciler adds a Reconciler Extension to the manager
+	//
+	// The manager later on, will register the Extension when Start() is being called.
+	AddReconciler(r Reconciler)
+
 	// Start starts the manager infinite loop.
 	//
 	// Registers all the Extensions and generates
@@ -92,6 +98,16 @@ type Manager interface {
 
 	// ListExtensions returns a list of the current loaded Extension
 	ListExtensions() []Extension
+
+	// ListReconcilers returns a list of the current loaded Reconcilers
+	ListReconcilers() []Reconciler
+
+	// GetContext returns the context of the manager, which can be used in internall cals by extension
+	GetContext() context.Context
+
+	// GetKubeManager returns the kubernetes manager which can be used by Reconcilers to perform
+	// direct requests
+	GetKubeManager() manager.Manager
 
 	// GetKubeConnection sets up a kube connection if not already present
 	//

--- a/manager_test.go
+++ b/manager_test.go
@@ -343,4 +343,19 @@ var _ = Describe("Extension Manager", func() {
 			Expect(len(eiriniServiceManager.ListExtensions())).To(Equal(1))
 		})
 	})
+
+	Context("Reconcilers", func() {
+		r := eirinixcatalog.SimpleReconciler()
+		BeforeEach(func() {
+			r = eirinixcatalog.SimpleReconciler()
+		})
+		It("Registers new reconcilers correctly", func() {
+			eiriniManager.AddReconciler(r)
+			Expect(len(eiriniManager.ListReconcilers())).To(Equal(1))
+			eiriniManager.AddReconciler(r)
+			Expect(len(eiriniManager.ListReconcilers())).To(Equal(2))
+		})
+
+	})
+
 })

--- a/manager_test.go
+++ b/manager_test.go
@@ -358,4 +358,32 @@ var _ = Describe("Extension Manager", func() {
 
 	})
 
+	Context("Registering different Extensions types from the same API", func() {
+		r := eirinixcatalog.SimpleReconciler()
+		w := eirinixcatalog.SimpleWatcher()
+		e := eirinixcatalog.SimpleExtension()
+		foo := struct{ Bar string }{}
+
+		BeforeEach(func() {
+			r = eirinixcatalog.SimpleReconciler()
+			w = eirinixcatalog.SimpleWatcher()
+			e = eirinixcatalog.SimpleExtension()
+			foo = struct{ Bar string }{}
+		})
+
+		It("Registers correctly with AddExtension", func() {
+			err := eiriniManager.AddExtension(e)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(eiriniManager.ListExtensions())).To(Equal(1))
+			err = eiriniManager.AddExtension(r)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(eiriniManager.ListReconcilers())).To(Equal(1))
+			err = eiriniManager.AddExtension(w)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(eiriniManager.ListWatchers())).To(Equal(1))
+
+			err = eiriniManager.AddExtension(foo)
+			Expect(err).To(HaveOccurred())
+		})
+	})
 })

--- a/testing/catalog.go
+++ b/testing/catalog.go
@@ -42,6 +42,12 @@ func (c *Catalog) SimpleExtension() eirinix.Extension {
 		parentExtension{Name: "test"}}
 }
 
+// SimpleReconciler it's returning a dummy Eirini reconciler extension
+// which adds the annotation "touched": "yes" to all created pods.
+func (c *Catalog) SimpleReconciler() eirinix.Reconciler {
+	return &testReconciler{}
+}
+
 // SimpleManager returns a dummy Extensions manager
 func (c *Catalog) SimpleManager() eirinix.Manager {
 	return eirinix.NewManager(

--- a/testing/extension.go
+++ b/testing/extension.go
@@ -33,6 +33,12 @@ func (e *EditEnvExtension) Handle(ctx context.Context, eiriniManager eirinix.Man
 	podCopy := pod.DeepCopy()
 	for i := range podCopy.Spec.Containers {
 		c := &podCopy.Spec.Containers[i]
+		for _, e := range c.Env {
+			if e.Name == "STICKY_MESSAGE" {
+				// was already patched
+				return eiriniManager.PatchFromPod(req, podCopy)
+			}
+		}
 		c.Env = append(c.Env, corev1.EnvVar{Name: "STICKY_MESSAGE", Value: "Eirinix is awesome!"})
 	}
 	return eiriniManager.PatchFromPod(req, podCopy)

--- a/testing/reconciler.go
+++ b/testing/reconciler.go
@@ -1,0 +1,83 @@
+package testing
+
+import (
+	"context"
+	"time"
+
+	eirinix "code.cloudfoundry.org/eirinix"
+	log "code.cloudfoundry.org/quarks-utils/pkg/ctxlog"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+type testReconciler struct {
+	mgr eirinix.Manager
+}
+
+func (r *testReconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	ctx := log.NewContextWithRecorder(r.mgr.GetContext(), "test-reconciler", r.mgr.GetKubeManager().GetEventRecorderFor("test-recorder"))
+	pod := &corev1.Pod{}
+
+	// Set the ctx to be Background, as the top-level context for incoming requests.
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	log.Info(ctx, "Reconciling pod ", request.NamespacedName)
+
+	if err := r.mgr.GetKubeManager().GetClient().Get(ctx, request.NamespacedName, pod); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// Simply make sure our annotation is there!
+	pod.ObjectMeta.Annotations["touched"] = "yes"
+	err := r.mgr.GetKubeManager().GetClient().Update(ctx, pod)
+	if err != nil {
+		log.WithEvent(pod, "UpdateError").Errorf(ctx, "Failed to update reconcile timestamp on restart annotated pod '%s/%s' (%v): %s", pod.Namespace, pod.Name, pod.ResourceVersion, err)
+		return reconcile.Result{Requeue: true}, nil
+	}
+	return reconcile.Result{}, nil
+}
+
+func (r *testReconciler) Register(m eirinix.Manager) error {
+	r.mgr = m
+
+	c, err := controller.New("test-controller", m.GetKubeManager(), controller.Options{
+		Reconciler: r,
+	})
+	if err != nil {
+		return errors.Wrap(err, "Adding restart controller to manager failed.")
+	}
+
+	// watch pods, trigger if one pod is created
+	p := predicate.Funcs{
+		CreateFunc:  func(e event.CreateEvent) bool { return true },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return false },
+		GenericFunc: func(e event.GenericEvent) bool { return false },
+		UpdateFunc:  func(e event.UpdateEvent) bool { return false },
+	}
+	err = c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestsFromMapFunc{
+		ToRequests: handler.ToRequestsFunc(func(a handler.MapObject) []reconcile.Request {
+			pod := a.Object.(*corev1.Pod)
+
+			result := []reconcile.Request{}
+			result = append(result, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      pod.Name,
+					Namespace: pod.Namespace,
+				}})
+			return result
+		}),
+	}, p)
+	if err != nil {
+		return errors.Wrapf(err, "Watching secrets failed in Restart controller failed.")
+	}
+
+	return nil
+}

--- a/testing/reconciler.go
+++ b/testing/reconciler.go
@@ -2,6 +2,7 @@ package testing
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	eirinix "code.cloudfoundry.org/eirinix"
@@ -30,16 +31,15 @@ func (r *testReconciler) Reconcile(request reconcile.Request) (reconcile.Result,
 	defer cancel()
 
 	log.Info(ctx, "Reconciling pod ", request.NamespacedName)
-
 	if err := r.mgr.GetKubeManager().GetClient().Get(ctx, request.NamespacedName, pod); err != nil {
-		return reconcile.Result{}, err
+		return reconcile.Result{Requeue: true}, err
 	}
 
 	// Simply make sure our annotation is there!
 	pod.ObjectMeta.Annotations["touched"] = "yes"
 	err := r.mgr.GetKubeManager().GetClient().Update(ctx, pod)
 	if err != nil {
-		log.WithEvent(pod, "UpdateError").Errorf(ctx, "Failed to update reconcile timestamp on restart annotated pod '%s/%s' (%v): %s", pod.Namespace, pod.Name, pod.ResourceVersion, err)
+		log.WithEvent(pod, "UpdateError").Errorf(ctx, "Failed to update pod annotation '%s/%s' (%v): %s", pod.Namespace, pod.Name, pod.ResourceVersion, err)
 		return reconcile.Result{Requeue: true}, nil
 	}
 	return reconcile.Result{}, nil
@@ -52,15 +52,79 @@ func (r *testReconciler) Register(m eirinix.Manager) error {
 		Reconciler: r,
 	})
 	if err != nil {
-		return errors.Wrap(err, "Adding restart controller to manager failed.")
+		return errors.Wrap(err, "Adding test controller to manager failed.")
 	}
 
 	// watch pods, trigger if one pod is created
 	p := predicate.Funcs{
 		CreateFunc:  func(e event.CreateEvent) bool { return true },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return true },
+		GenericFunc: func(e event.GenericEvent) bool { return true },
+		UpdateFunc:  func(e event.UpdateEvent) bool { return true },
+	}
+	err = c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestsFromMapFunc{
+		ToRequests: handler.ToRequestsFunc(func(a handler.MapObject) []reconcile.Request {
+			pod := a.Object.(*corev1.Pod)
+
+			result := []reconcile.Request{}
+			result = append(result, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      pod.Name,
+					Namespace: pod.Namespace,
+				}})
+			return result
+		}),
+	}, p)
+	if err != nil {
+		return errors.Wrapf(err, "Watching secrets failed in Restart controller failed.")
+	}
+
+	return nil
+}
+
+type EditImageReconciler struct {
+	mgr eirinix.Manager
+}
+
+func (r *EditImageReconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	ctx := log.NewContextWithRecorder(r.mgr.GetContext(), "test-reconciler", r.mgr.GetKubeManager().GetEventRecorderFor("test-recorder"))
+	pod := &corev1.Pod{}
+
+	// Set the ctx to be Background, as the top-level context for incoming requests.
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	log.Info(ctx, "Reconciling pod ", request.NamespacedName)
+	if err := r.mgr.GetKubeManager().GetClient().Get(ctx, request.NamespacedName, pod); err != nil {
+		return reconcile.Result{Requeue: true}, err
+	}
+
+	pod.Spec.Containers[0].Image = "opensuse/leap"
+	err := r.mgr.GetKubeManager().GetClient().Update(ctx, pod)
+	if err != nil {
+		fmt.Println("Error during pod update", err)
+		log.WithEvent(pod, "UpdateError").Errorf(ctx, "Failed to update pod annotation '%s/%s' (%v): %s", pod.Namespace, pod.Name, pod.ResourceVersion, err)
+		return reconcile.Result{Requeue: true}, nil
+	}
+	return reconcile.Result{}, nil
+}
+
+func (r *EditImageReconciler) Register(m eirinix.Manager) error {
+	r.mgr = m
+
+	c, err := controller.New("test-controller", m.GetKubeManager(), controller.Options{
+		Reconciler: r,
+	})
+	if err != nil {
+		return errors.Wrap(err, "Adding test controller to manager failed.")
+	}
+
+	// watch pods, trigger if one pod is created
+	p := predicate.Funcs{
+		CreateFunc:  func(e event.CreateEvent) bool { return false },
 		DeleteFunc:  func(e event.DeleteEvent) bool { return false },
 		GenericFunc: func(e event.GenericEvent) bool { return false },
-		UpdateFunc:  func(e event.UpdateEvent) bool { return false },
+		UpdateFunc:  func(e event.UpdateEvent) bool { return true },
 	}
 	err = c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestsFromMapFunc{
 		ToRequests: handler.ToRequestsFunc(func(a handler.MapObject) []reconcile.Request {

--- a/testing/utils.go
+++ b/testing/utils.go
@@ -43,9 +43,14 @@ type PodStatus struct {
 type PodSpec struct {
 	Containers []Container `json:"containers"`
 }
+
+type ObjectMeta struct {
+	Annotations map[string]string `json:"annotations"`
+}
 type Pod struct {
-	Spec      PodSpec   `json:"spec"`
-	PodStatus PodStatus `json:"status"`
+	Metadata  ObjectMeta `json:"metadata"`
+	Spec      PodSpec    `json:"spec"`
+	PodStatus PodStatus  `json:"status"`
 }
 
 func (p *Pod) IsRunning() bool {

--- a/testing/utils.go
+++ b/testing/utils.go
@@ -33,8 +33,9 @@ type ContainerEnv struct {
 	Value string `json:"value"`
 }
 type Container struct {
-	Name string         `json:"name"`
-	Envs []ContainerEnv `json:"env"`
+	Name  string         `json:"name"`
+	Image string         `json:"image"`
+	Envs  []ContainerEnv `json:"env"`
 }
 
 type PodStatus struct {


### PR DESCRIPTION
In this way we can express extensions as reconcilers, giving more control on how resources are patched, besides the mutatingwebhook method which is already existing.

The interface is defined in the following way (TBD):
```golang
// Reconciler is the Eirini Reconciler Extension interface
//
// An Eirini Reconciler must implement a Reconcile method which is called when
// a new request is being created.
type Reconciler interface {
	Reconcile(request reconcile.Request) (reconcile.Result, error)
	Register(Manager) error
}
```

To note, there is no change in the execution flow of EiriniX manager: both extensions and reconcilers are registered together while starting up the operator in the same process execution.

Yet todo: polish and reduce the amount of boilerplate needed when declaring EiriniX reconcilers.

Relates/Rationale: https://github.com/cloudfoundry-incubator/kubecf/issues/923#issuecomment-686527887

cc: @viovanov @jimmykarily 