### PR TITLE
Moving context creation in OperatorSetup()

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -374,6 +374,12 @@ func (m *DefaultExtensionManager) GenWebHookServer() {
 // It also setups the namespace label for the operator
 func (m *DefaultExtensionManager) OperatorSetup() error {
 
+	if m.GetManagerOptions().Context == nil {
+		m.Context = ctxlog.NewManagerContext(m.Logger)
+	} else {
+		m.Context = *m.GetManagerOptions().Context
+	}
+
 	m.GenWebHookServer()
 
 	if m.Options.Namespace != "" {
@@ -561,12 +567,6 @@ func (m *DefaultExtensionManager) Watch() error {
 // Start starts the Manager infinite loop, and returns an error on failure
 func (m *DefaultExtensionManager) Start() error {
 	defer m.Logger.Sync()
-
-	if m.GetManagerOptions().Context == nil {
-		m.Context = ctxlog.NewManagerContext(m.Logger)
-	} else {
-		m.Context = *m.GetManagerOptions().Context
-	}
 
 	if len(m.Watchers) >= 0 {
 		go m.Watch()


### PR DESCRIPTION
OperatorSetup is public, and it's used when splitting extension runtime from registration.