### PR TITLE
Move concourse-ci from cloudfoundry-incubator/eirinix-helm-release

### DIFF
--- a/.concourse/.gitignore
+++ b/.concourse/.gitignore
@@ -1,0 +1,1 @@
+/config.yaml

--- a/.concourse/README.md
+++ b/.concourse/README.md
@@ -32,5 +32,5 @@ Deploy the pipeline using the `fly` script in this directory:
 ### Pipeline development
 
 If you wish to deploy a copy of this pipeline for development (without
-publishing) artifacts to the official places), create a `configl.yaml` file
+publishing) artifacts to the official places), create a `config.yaml` file
 based on `config.yaml.sample` and deploy normally.

--- a/.concourse/README.md
+++ b/.concourse/README.md
@@ -1,0 +1,36 @@
+# eirinix-helm-release pipeline
+
+[This pipeline] builds the SUSE Eirini extensions docker images, as well as
+building the SUSE Eirini extensions helm chart.  They are for use with [kubecf].
+
+[This pipeline]: https://concourse.suse.dev/teams/main/pipelines/eirinix
+[kubecf]: https://code.cloudfoundry.org/kubecf
+
+## Deploying the pipeline
+
+### Prerequisites
+
+Deploying this pipeline requires a [concourse] installation, as well as having
+[gomplate] available locally.
+
+[concourse]: https:/concourse-ci.org/
+[gomplate]: https://gomplate.ca/
+
+The concourse [credential manager] is also required to have the
+`docker-username` and `docker-password` credentials available.
+
+[credential manager]: https://concourse-ci.org/creds.html
+
+### Deploy on concourse
+
+Deploy the pipeline using the `fly` script in this directory:
+
+```bash
+./fly -t target set-pipeline
+```
+
+### Pipeline development
+
+If you wish to deploy a copy of this pipeline for development (without
+publishing) artifacts to the official places), create a `configl.yaml` file
+based on `config.yaml.sample` and deploy normally.

--- a/.concourse/config.yaml.sample
+++ b/.concourse/config.yaml.sample
@@ -11,6 +11,8 @@ git:
 repos:
   trigger: false                   # whether to automatically trigger builds
   org: ~                           # SUSE
+  token:                           ((github-access-token))
+  key:                             ((github-private-key))
   # Per-repo overrides are also possible; these include the org.
   eirini-loggregator-bridge: ~     # SUSE/eirini-loggregator-bridge
   eirini-persi: ~                  # SUSE/eirini-persi
@@ -19,12 +21,12 @@ repos:
   eirinix-helm-release: ~          # SUSE/eirinix-helm-release
 
 s3:
-  bucket: eirini-suse
-  prefix: ""
-  access_key_id: ~
-  secret_access_key: ~
-  session_token: ~
-  region_name: us-east-1
-  private: false
-  endpoint: ~
-  disable_ssl: false
+  bucket:            eirini-suse
+  prefix:            ""
+  access_key_id:     ((aws-access-key))
+  secret_access_key: ((aws-secret-key))
+  session_token:     ~
+  region_name:       us-east-1
+  private:           false
+  endpoint:          ~
+  disable_ssl:       false

--- a/.concourse/config.yaml.sample
+++ b/.concourse/config.yaml.sample
@@ -9,10 +9,11 @@ git:
   email: ~ # cf-ci-bot@suse.de
 
 repos:
-  trigger: false            # whether to automatically trigger builds
-  org: ~                    # SUSE
+  trigger: false                   # whether to automatically trigger builds
+  org: ~                           # SUSE
   # Per-repo overrides are also possible; these include the org.
-  loggregator-bridge: ~     # SUSE/eirini-loggregator-bridge
-  persi: ~                  # SUSE/eirini-persi
-  persi-broker: ~           # SUSE/eirini-persi-broker
-  ssh: ~                    # SUSE/eirini-ssh
+  eirini-loggregator-bridge: ~     # SUSE/eirini-loggregator-bridge
+  eirini-persi: ~                  # SUSE/eirini-persi
+  eirini-persi-broker: ~           # SUSE/eirini-persi-broker
+  eirini-ssh: ~                    # SUSE/eirini-ssh
+  eirinix-helm-release: ~          # SUSE/eirinix-helm-release

--- a/.concourse/config.yaml.sample
+++ b/.concourse/config.yaml.sample
@@ -2,7 +2,7 @@
 # pipeline are used.
 
 docker:
-  org: ~ # splatform
+  repository: ~ # splatform
 
 git:
   user: ~  # SUSE CFCIBot

--- a/.concourse/config.yaml.sample
+++ b/.concourse/config.yaml.sample
@@ -17,3 +17,14 @@ repos:
   eirini-persi-broker: ~           # SUSE/eirini-persi-broker
   eirini-ssh: ~                    # SUSE/eirini-ssh
   eirinix-helm-release: ~          # SUSE/eirinix-helm-release
+
+s3:
+  bucket: eirini-suse
+  prefix: ""
+  access_key_id: ~
+  secret_access_key: ~
+  session_token: ~
+  region_name: us-east-1
+  private: false
+  endpoint: ~
+  disable_ssl: false

--- a/.concourse/config.yaml.sample
+++ b/.concourse/config.yaml.sample
@@ -1,0 +1,18 @@
+# All values are optional; if not provided, hard-coded production values in the
+# pipeline are used.
+
+docker:
+  org: ~ # cfcontainerization
+
+git:
+  user: ~  # SUSE CFCIBot
+  email: ~ # cf-ci-bot@suse.de
+
+repos:
+  trigger: false            # whether to automatically trigger builds
+  org: ~                    # SUSE
+  # Per-repo overrides are also possible; these include the org.
+  loggregator-bridge: ~     # SUSE/eirini-loggregator-bridge
+  persi: ~                  # SUSE/eirini-persi
+  persi-broker: ~           # SUSE/eirini-persi-broker
+  ssh: ~                    # SUSE/eirini-ssh

--- a/.concourse/config.yaml.sample
+++ b/.concourse/config.yaml.sample
@@ -3,6 +3,8 @@
 
 docker:
   repository: ~ # splatform
+  username: ((docker-username))
+  password: ((docker-password))
 
 git:
   user: ~  # SUSE CFCIBot

--- a/.concourse/config.yaml.sample
+++ b/.concourse/config.yaml.sample
@@ -2,7 +2,7 @@
 # pipeline are used.
 
 docker:
-  org: ~ # cfcontainerization
+  org: ~ # splatform
 
 git:
   user: ~  # SUSE CFCIBot

--- a/.concourse/fly
+++ b/.concourse/fly
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# This script should be used instead of Concourse "fly" cli in order to deploy
+# the pipeline. It simply calls "gomplate" to render the final pipeline definition.
+# It delegated all other options to the real "fly".
+#
+# E.g. ./fly -t target set-pipeline
+
+set -o errtrace -o errexit -o nounset -o pipefail
+
+if ! type -t gomplate >/dev/null ; then
+  echo "gomplate missing. Follow the instructions in https://docs.gomplate.ca/installing/ and install it first."
+  exit 1
+fi
+
+command=( gomplate --verbose --file pipeline.yaml.gomplate )
+pipeline="eirinix"
+if [[ -r config.yaml ]]; then
+  command+=(--context ".=config.yaml")
+  pipeline="${USER}-${pipeline}"
+fi
+
+"${command[@]}" >/dev/null # Check for template rendering failures
+fly "${@}" --config <("${command[@]}") --pipeline "${pipeline}"

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -8,8 +8,8 @@
 
 {{- /* $.docker */ -}}
 {{- $ = dict | dict "docker" | merge $ -}}
-{{- /* .docker.org */ -}}
-{{- $ = merge (index $.docker "org" | default "splatform" | dict "org" | dict "docker") $ -}}
+{{- /* .docker.repository */ -}}
+{{- $ = merge (index $.docker "repository" | default "splatform" | dict "repository" | dict "docker") $ -}}
 {{- /* .git */ -}}
 {{- $ = dict | dict "git" | merge $ -}}
 {{- /* .git.user */ -}}
@@ -120,7 +120,7 @@ resources:
 - name: docker.{{ . }}
   type: docker-image
   source:
-    repository: {{ $.docker.org }}/eirinix-{{ . }}
+    repository: {{ $.docker.repository }}/eirinix-{{ . }}
     username:   ((docker-username))
     password:   ((docker-password))
 - name: s3.{{ . }}-version
@@ -142,7 +142,7 @@ resources:
 - name: docker.package-base
   type: docker-image
   source:
-    repository: {{ $.docker.org }}/eirinix-package-base
+    repository: {{ $.docker.repository }}/eirinix-package-base
     username:   ((docker-username))
     password:   ((docker-password))
 
@@ -234,21 +234,21 @@ jobs:
         {{- if . | strings.HasSuffix "-setup" | not }}
         {{ . }}:
           image:
-            repository: {{ $.docker.org }}
+            repository: {{ $.docker.repository }}
             tag: <%= File.read('../s3.{{ . }}-version/version') %>
           {{- if printf "%s-setup" . | has $images }}
           setup-image:
-            repository: {{ $.docker.org }}
+            repository: {{ $.docker.repository }}
             tag: <%= File.read('../s3.{{ . }}-setup-version/version') %>
           {{- end }}
         {{- end }}
         {{- end }}
         ssh-proxy:
           image:
-            repository: {{ $.docker.org }}
+            repository: {{ $.docker.repository }}
             tag: <%= File.read('../s3.ssh-version/version') %>
           setup-image:
-            repository: {{ $.docker.org }}
+            repository: {{ $.docker.repository }}
             tag: <%= File.read('../s3.ssh-proxy-setup-version/version') %>
   - put: s3.chart
     params:

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -2,7 +2,7 @@
 {{- /* list of repositories and output images */ -}}
 
 {{- $repos := slice "eirini-loggregator-bridge" "eirini-persi" "eirini-persi-broker" "eirini-ssh" "eirinix-helm-release" }}
-{{- $images := slice "loggregator-bridge" "persi" "persi-broker" "persi-broker-setup" "ssh" "ssh-proxy-setup" }}
+{{- $images := slice "loggregator-bridge" "persi" "persi-broker" "ssh" "persi-broker-setup" "ssh-proxy-setup" }}
 
 {{- /* configure default values */ -}}
 
@@ -222,9 +222,27 @@ jobs:
         - --destination=../output
     image: docker.package-base
     params:
-      {{- range $images }}
-      TAG_FILE_{{ . | strings.SnakeCase | toUpper }}: ../s3.{{ . }}-version/version
-      {{- end }}
+      OVERRIDES: |
+        {{- range $images }}
+        {{- if . | strings.HasSuffix "-setup" | not }}
+        {{ . }}:
+          image:
+            repository: {{ $.docker.org }}
+            tag: <%= File.read('../s3.{{ . }}-version/version') %>
+          {{- if printf "%s-setup" . | has $images }}
+          setup-image:
+            repository: {{ $.docker.org }}
+            tag: <%= File.read('../s3.{{ . }}-setup-version/version') %>
+          {{- end }}
+        {{- end }}
+        {{- end }}
+        ssh-proxy:
+          image:
+            repository: {{ $.docker.org }}
+            tag: <%= File.read('../s3.ssh-version/version') %>
+          setup-image:
+            repository: {{ $.docker.org }}
+            tag: <%= File.read('../s3.ssh-proxy-setup-version/version') %>
   - put: s3.chart
     params:
       file: output/eirini-extensions-*.tgz

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -71,8 +71,9 @@
         args:
         - -c
         - >
-          git config --global user.name  $GIT_AUTHOR_NAME ;
-          git config --global user.email $GIT_AUTHOR_EMAIL ;
+          set -o errexit -o nounset ;
+          git config --global user.name  "$GIT_AUTHOR_NAME" ;
+          git config --global user.email "$GIT_AUTHOR_EMAIL" ;
           (
             cd src ;
             if [ -r bin/include/versioning ] ; then
@@ -118,6 +119,12 @@ resources:
     branch: master
     uri: https://github.com/{{ index $.repos . }}
 {{ end }}
+- name: git.chart-repository
+  type: git
+  source:
+    branch: gh-pages
+    uri: git@github.com:{{ index $.repos "eirinix-helm-release" }}
+    private_key: {{ $.repos.key }}
 - name: github-release.chart
   type: github-release
   source:
@@ -256,10 +263,46 @@ jobs:
           setup-image:
             repository: {{ $.docker.repository }}
             tag: <%= File.read('../s3.ssh-proxy-setup-version/version') %>
-  - put: github-release.chart
-    params:
-      name: output/version.txt
-      tag: output/version.txt
-      tag_prefix: v
-      commitish: output/commit.txt
-      globs: [ output/eirini-extensions-*.tgz ]
+  - in_parallel:
+    - put: github-release.chart
+      params:
+        name: output/version.txt
+        tag: output/version.txt
+        tag_prefix: v
+        commitish: output/commit.txt
+        globs: [ output/eirini-extensions-*.tgz ]
+    - do:
+      - get: git.chart-repository
+      - task: regenerate-chart-repo
+        config:
+          platform: linux
+          inputs:
+          - name: git.chart-repository
+          - name: output
+          outputs:
+          - name: git.chart-repository
+          params:
+            GIT_AUTHOR_NAME: {{ $.git.user }}
+            GIT_AUTHOR_EMAIL: {{ $.git.email }}
+            FULL_REPO: {{ index $.repos "eirinix-helm-release" }}
+          run:
+            dir: git.chart-repository
+            path: /bin/sh
+            args:
+            - -c
+            - >
+              set -o errexit -o nounset -o xtrace ;
+              VERSION="$(cat ../output/version.txt)" ;
+              ORG="${FULL_REPO%%/*}" ;
+              REPO="${FULL_REPO#*/}" ;
+              URL="https://${ORG}.github.io/${REPO}/" ;
+              cp ../output/eirini-extensions-*.tgz . ;
+              helm repo index --merge index.yaml --url "${URL}" . ;
+              git config --global user.name  "$GIT_AUTHOR_NAME" ;
+              git config --global user.email "$GIT_AUTHOR_EMAIL" ;
+              git add "eirini-extensions-${VERSION}"*.tgz index.yaml ;
+              git commit -m "Add version ${VERSION}" ;
+        image: docker.package-base
+      - put: git.chart-repository
+        params:
+          repository: git.chart-repository

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -35,6 +35,28 @@
   - get: git.{{ $.repo }}
     trigger: {{ $.repos.trigger }}
     version: every
+  - task: get-version
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source: { repository: opensuse/leap }
+      inputs:
+      - name: git.{{ $.repo }}
+        path: src
+      outputs:
+      - name: tag
+      run:
+        path: /bin/sh
+        args:
+        - -c
+        - >
+          export XTRACE=on ;
+          (
+            cd src ;
+            bin/include/versioning
+          ) > tag/tag.txt
+
   - put: docker.{{ $.image }}
     params:
       build: git.{{ $.repo }}/
@@ -42,6 +64,7 @@
         USER: {{ $.git.user }}
         EMAIL: {{ $.git.email }}
         # BASE_IMAGE: scratch # FIXME: images are missing /tmp folder, which makes extensions to crash
+      tag_file: tag/tag.txt
 {{ end }}
 
 groups:

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -80,7 +80,7 @@
               . bin/include/versioning ;
               echo $VERSION_TAG ;
             else
-              git describe --tags --long || \
+              git describe --tags --long --exclude '*+g*' || \
                 printf "v0.0.0-g%s" "$(git describe --always)"
             fi
           ) > tag/tag.txt ;
@@ -102,7 +102,7 @@
 
 groups:
 - name: chart
-  jobs: [ package-base, chart ]
+  jobs: [ package-base, chart, update-repo ]
 - name: logging
   jobs: [ loggregator-bridge ]
 - name: persi
@@ -236,12 +236,11 @@ jobs:
       run:
         dir: git.eirinix-helm-release
         path: bin/package
-        args:
-        - --destination=../output
     image: docker.package-base
     params:
       VERSION_FILE: ../output/version.txt
       COMMIT_HASH_FILE: ../output/commit.txt
+      OUTPUT_DIR: ../output/
       OVERRIDES: |
         {{- range $images }}
         {{- if . | strings.HasSuffix "-setup" | not }}
@@ -263,46 +262,43 @@ jobs:
           setup-image:
             repository: {{ $.docker.repository }}
             tag: <%= File.read('../s3.ssh-proxy-setup-version/version') %>
+  - put: github-release.chart
+    params:
+      name: output/version.txt
+      tag: output/version.txt
+      tag_prefix: v
+      commitish: output/commit.txt
+      globs: [ output/eirini-extensions-*.tgz ]
+- name: update-repo
+  serial: true
+  plan:
   - in_parallel:
-    - put: github-release.chart
+    - get: docker.package-base
+    - get: git.eirinix-helm-release
+    - get: git.chart-repository
+    - get: github-release.chart
+      trigger: {{ $.repos.trigger }}
+      passed: [ chart ]
       params:
-        name: output/version.txt
-        tag: output/version.txt
-        tag_prefix: v
-        commitish: output/commit.txt
-        globs: [ output/eirini-extensions-*.tgz ]
-    - do:
-      - get: git.chart-repository
-      - task: regenerate-chart-repo
-        config:
-          platform: linux
-          inputs:
-          - name: git.chart-repository
-          - name: output
-          outputs:
-          - name: git.chart-repository
-          params:
-            GIT_AUTHOR_NAME: {{ $.git.user }}
-            GIT_AUTHOR_EMAIL: {{ $.git.email }}
-            FULL_REPO: {{ index $.repos "eirinix-helm-release" }}
-          run:
-            dir: git.chart-repository
-            path: /bin/sh
-            args:
-            - -c
-            - >
-              set -o errexit -o nounset -o xtrace ;
-              VERSION="$(cat ../output/version.txt)" ;
-              ORG="${FULL_REPO%%/*}" ;
-              REPO="${FULL_REPO#*/}" ;
-              URL="https://${ORG}.github.io/${REPO}/" ;
-              cp ../output/eirini-extensions-*.tgz . ;
-              helm repo index --merge index.yaml --url "${URL}" . ;
-              git config --global user.name  "$GIT_AUTHOR_NAME" ;
-              git config --global user.email "$GIT_AUTHOR_EMAIL" ;
-              git add "eirini-extensions-${VERSION}"*.tgz index.yaml ;
-              git commit -m "Add version ${VERSION}" ;
-        image: docker.package-base
-      - put: git.chart-repository
-        params:
-          repository: git.chart-repository
+        globs: [ eirini-extensions-*.tgz ]
+  - task: regenerate-chart-repo
+    config:
+      platform: linux
+      inputs:
+      - name: git.chart-repository
+      - name: git.eirinix-helm-release
+      - name: github-release.chart
+      outputs:
+      - name: git.chart-repository
+      params:
+        GIT_AUTHOR_NAME: {{ $.git.user }}
+        GIT_AUTHOR_EMAIL: {{ $.git.email }}
+        REPO: {{ index $.repos "eirinix-helm-release" }}
+      run:
+        path: ../git.eirinix-helm-release/bin/update-helm-index.rb
+        dir: git.chart-repository
+        args: [ ../github-release.chart ]
+    image: docker.package-base
+  - put: git.chart-repository
+    params:
+      repository: git.chart-repository

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -256,19 +256,10 @@ jobs:
           setup-image:
             repository: {{ $.docker.repository }}
             tag: <%= File.read('../s3.ssh-proxy-setup-version/version') %>
-  - task: release-prep
-    config:
-      platform: linux
-      outputs:
-      - name: release-prep
-      run:
-        path: /bin/sh
-        args: [ -c, "echo -n v > release-prep/tag-prefix.txt" ]
-    image: docker.package-base
   - put: github-release.chart
     params:
       name: output/version.txt
       tag: output/version.txt
-      tag_prefix: release-prep/tag-prefix.txt
+      tag_prefix: v
       commitish: output/commit.txt
       globs: [ output/eirini-extensions-*.tgz ]

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -22,6 +22,10 @@
 {{- $ = merge (index $.repos "trigger" | default true | dict "trigger" | dict "repos") $ -}}
 {{- /* .repos.org */ -}}
 {{- $ = merge (index $.repos "org" | default "SUSE" | dict "org" | dict "repos") $ -}}
+{{- /* .repos.token */ -}}
+{{- $ = merge (index $.repos "token" | default "((github-access-token))" | dict "token" | dict "repos") $ -}}
+{{- /* .repos.key */ -}}
+{{- $ = merge (index $.repos "key" | default "((github-private-key))" | dict "key" | dict "repos") $ -}}
 {{- /* .repos.<repo> */ -}}
 {{- range $repos -}}
 {{- $ = merge (index $.repos . | default (printf "%s/%s" $.repos.org .) | dict . | dict "repos") $ -}}
@@ -114,6 +118,14 @@ resources:
     branch: master
     uri: https://github.com/{{ index $.repos . }}
 {{ end }}
+- name: github-release.chart
+  type: github-release
+  source:
+    owner: {{ $.repos.org }}
+    repository: eirinix-helm-release
+    access_token: {{ $.repos.token }}
+    release: false
+    pre_release: true
 
 # Docker image outputs
 {{ range $images }}
@@ -123,16 +135,6 @@ resources:
     repository: {{ $.docker.repository }}/eirinix-{{ . }}
     username:   ((docker-username))
     password:   ((docker-password))
-- name: s3.{{ . }}-version
-  type: s3
-  source:
-    bucket: {{ $.s3.bucket }}
-    {{- range keys $.s3 }}
-    {{- if has (slice "bucket" "prefix") . | not }}
-    {{ . }}: {{ index $.s3 . }}
-    {{- end }}
-    {{- end }}
-    regexp: {{ $.s3.prefix | default ""  }}image-{{ . }}-tag-(.*).txt
 {{ end }}
 - name: docker.base
   type: docker-image
@@ -146,8 +148,9 @@ resources:
     username:   ((docker-username))
     password:   ((docker-password))
 
-# S3 bucket for chart
-- name: s3.chart
+# S3 resources
+{{ range $images }}
+- name: s3.{{ . }}-version
   type: s3
   source:
     bucket: {{ $.s3.bucket }}
@@ -156,7 +159,8 @@ resources:
     {{ . }}: {{ index $.s3 . }}
     {{- end }}
     {{- end }}
-    regexp: {{ $.s3.prefix | default "" }}eirini-extensions-(.*).tgz
+    regexp: {{ $.s3.prefix | default ""  }}image-{{ . }}-tag-(.*).txt
+{{ end }}
 
 jobs:
 # group logging
@@ -229,6 +233,8 @@ jobs:
         - --destination=../output
     image: docker.package-base
     params:
+      VERSION_FILE: ../output/version.txt
+      COMMIT_HASH_FILE: ../output/commit.txt
       OVERRIDES: |
         {{- range $images }}
         {{- if . | strings.HasSuffix "-setup" | not }}
@@ -250,7 +256,19 @@ jobs:
           setup-image:
             repository: {{ $.docker.repository }}
             tag: <%= File.read('../s3.ssh-proxy-setup-version/version') %>
-  - put: s3.chart
+  - task: release-prep
+    config:
+      platform: linux
+      outputs:
+      - name: release-prep
+      run:
+        path: /bin/sh
+        args: [ -c, "echo -n v > release-prep/tag-prefix.txt" ]
+    image: docker.package-base
+  - put: github-release.chart
     params:
-      file: output/eirini-extensions-*.tgz
-      acl: public-read
+      name: output/version.txt
+      tag: output/version.txt
+      tag_prefix: release-prep/tag-prefix.txt
+      commitish: output/commit.txt
+      globs: [ output/eirini-extensions-*.tgz ]

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -102,7 +102,7 @@
 
 groups:
 - name: chart
-  jobs: [ package-base, chart, update-repo ]
+  jobs: [ package-base, chart ]
 - name: logging
   jobs: [ loggregator-bridge ]
 - name: persi
@@ -119,12 +119,6 @@ resources:
     branch: master
     uri: https://github.com/{{ index $.repos . }}
 {{ end }}
-- name: git.chart-repository
-  type: git
-  source:
-    branch: gh-pages
-    uri: git@github.com:{{ index $.repos "eirinix-helm-release" }}
-    private_key: {{ $.repos.key }}
 - name: github-release.chart
   type: github-release
   source:
@@ -269,36 +263,4 @@ jobs:
       tag_prefix: v
       commitish: output/commit.txt
       globs: [ output/eirini-extensions-*.tgz ]
-- name: update-repo
-  serial: true
-  plan:
-  - in_parallel:
-    - get: docker.package-base
-    - get: git.eirinix-helm-release
-    - get: git.chart-repository
-    - get: github-release.chart
-      trigger: {{ $.repos.trigger }}
-      passed: [ chart ]
-      params:
-        globs: [ eirini-extensions-*.tgz ]
-  - task: regenerate-chart-repo
-    config:
-      platform: linux
-      inputs:
-      - name: git.chart-repository
-      - name: git.eirinix-helm-release
-      - name: github-release.chart
-      outputs:
-      - name: git.chart-repository
-      params:
-        GIT_AUTHOR_NAME: {{ $.git.user }}
-        GIT_AUTHOR_EMAIL: {{ $.git.email }}
-        REPO: {{ index $.repos "eirinix-helm-release" }}
-      run:
-        path: ../git.eirinix-helm-release/bin/update-helm-index.rb
-        dir: git.chart-repository
-        args: [ ../github-release.chart ]
-    image: docker.package-base
-  - put: git.chart-repository
-    params:
-      repository: git.chart-repository
+      body: output/body.txt

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -34,6 +34,10 @@
 {{- $ = merge (index $.s3 "prefix" | default "" | dict "prefix" | dict "s3") $ -}}
 {{- /* $.s3.region_name */ -}}
 {{- $ = merge (index $.s3 "region_name" | default "us-east-1" | dict "region_name" | dict "s3") $ -}}
+{{- /* $.s3.access_key_id */ -}}
+{{- $ = merge (index $.s3 "access_key_id" | default "((aws-access-key))" | dict "access_key_id" | dict "s3") $ -}}
+{{- /* $.s3.secret_access_key */ -}}
+{{- $ = merge (index $.s3 "secret_access_key" | default "((aws-secret-key))" | dict "secret_access_key" | dict "s3") $ -}}
 
 {{- /* This template builds a go binary from source */ -}}
 {{- /* Requires `.repo`, `.image`, and `.subdir` keys */ -}}

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -2,7 +2,7 @@
 {{/* list of repositories and output images */}}
 
 {{ $repos := slice "loggregator-bridge" "persi" "persi-broker" "ssh" }}
-{{ $images := slice "loggregator-bridge" "persi" "persi-broker" "ssh" "ssh-proxy" }}
+{{ $images := slice "loggregator-bridge" "persi" "persi-broker" "ssh" }}
 
 {{/* configure default values */}}
 
@@ -29,61 +29,28 @@
 
 {{/* This template builds a go binary from source */}}
 {{/* Requires `.repo`, `.image`, and `.subdir` keys */}}
-{{ define "direct-build" }}
+{{ define "build-image" }}
 - name: {{ $.image }}
   plan:
-  - get: docker.build-base
   - get: git.{{ $.repo }}
     trigger: {{ $.repos.trigger }}
     version: every
-  - task: build
-    config:
-      platform: linux
-      inputs:
-      - name: src
-      outputs:
-      - name: bin
-      caches:
-      - path: cache
-      run:
-        path: /bin/sh
-        args:
-        - -c
-        - >
-          set -o errexit -o nounset -o xtrace ;
-          export GOCACHE=$PWD/cache ;
-          OUTFILE=${PWD}/bin/{{ $.image }} ;
-          cd src ;
-          GO111MODULES=on go mod vendor ;
-          go build -o ${OUTFILE} ./{{ $.subdir }}/
-    image: docker.build-base
-    input_mapping:
-      src: git.{{ $.repo }}
-  - task: image
-    config:
-      platform: linux
-      inputs:
-      - name: bin
-      outputs:
-      - name: image
-      run:
-        path: /usr/bin/tar
-        args: [ cf, image/image.tar, -C, bin, {{ $.image }} ]
-    image: docker.build-base
   - put: docker.{{ $.image }}
     params:
-      import_file: image/image.tar
+      build: git.{{ $.repo }}/
+      build_args:
+        USER: {{ $.git.user }}
+        EMAIL: {{ $.git.email }}
+        # BASE_IMAGE: scratch # FIXME: images are missing /tmp folder, which makes extensions to crash
 {{ end }}
 
 groups:
-- name: build-base
-  jobs: [ build-base ]
 - name: logging
   jobs: [ loggregator-bridge ]
 - name: persi
   jobs: [ persi, persi-broker ]
 - name: ssh
-  jobs: [ ssh, ssh-proxy ]
+  jobs: [ ssh ]
 
 resources:
 # source GitHub repositories
@@ -103,77 +70,21 @@ resources:
     repository: {{ $.docker.org }}/eirinix-{{ . }}
     username:   ((docker-username))
     password:   ((docker-password))
-    build_args:
-      user: {{ $.git.user }}
-      email: {{ $.git.email }}
-
 {{ end }}
 
-# Docker image for building images
-- name: docker.build-base
-  type: docker-image
-  source:
-    repository: {{ $.docker.org }}/eirinix-build-base
-    username:   ((docker-username))
-    password:   ((docker-password))
-
 jobs:
-
-# Job to construct docker.build-base
-- name: build-base
-  plan:
-  - task: dockerfile
-    config:
-      platform: linux
-      image_resource:
-        type: registry-image
-        source: { repository: opensuse/leap }
-      outputs:
-      - name: out
-      run:
-        path: /bin/sh
-        args:
-        - -c
-        - echo "${DATA}" > out/Dockerfile
-      params:
-        DATA: |
-          FROM opensuse/leap
-          RUN true \
-            && zypper --non-interactive refresh \
-            && zypper --non-interactive install \
-              git-core \
-              bzr \
-              python-openssl \
-              'go >= 1.12' \
-              tar \
-            && zypper --non-interactive clean
-  - put: docker.build-base
-    params:
-      build: out
-
 {{ if has $images "loggregator-bridge" }}
-- name: loggregator-bridge
-  plan:
-  - get: git.loggregator-bridge
-    trigger: {{ $.repos.trigger }}
-    version: every
-  - put: docker.loggregator-bridge
-    params:
-      build: git.loggregator-bridge
+{{ template "build-image" (dict "repo" "loggregator-bridge" "image" "loggregator-bridge" | merge $) }}
 {{ end }}
 
 {{ if has $images "persi" }}
-{{ template "direct-build" (dict "repo" "persi" "subdir" "cmd/eirini-ext" "image" "persi" | merge $) }}
+{{ template "build-image" (dict "repo" "persi" "image" "persi" | merge $) }}
 {{ end }}
 
 {{ if has $images "persi-broker" }}
-{{ template "direct-build" (dict "repo" "persi-broker" "subdir" "cmd/broker" "image" "persi-broker" | merge $) }}
+{{ template "build-image" (dict "repo" "persi-broker" "image" "persi-broker" | merge $) }}
 {{ end }}
 
 {{ if has $images "ssh" }}
-{{ template "direct-build" (dict "repo" "ssh" "subdir" "cmd/extension" "image" "ssh" | merge $) }}
-{{ end }}
-
-{{ if has $images "ssh-proxy" }}
-{{ template "direct-build" (dict "repo" "ssh" "subdir" "cmd/ssh-proxy" "image" "ssh-proxy" | merge $) }}
+{{ template "build-image" (dict "repo" "ssh" "image" "ssh" | merge $) }}
 {{ end }}

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -6,16 +6,22 @@
 
 {{/* configure default values */}}
 
+{{/* $.docker */}}
+{{ $ = dict | dict "docker" | merge $ }}
 {{/* .docker.org */}}
-{{ $ = merge (default "cfcontainerization" $.docker.org | dict "org" | dict "docker") $ }}
+{{ $ = merge (index $.docker "org" | default "splatform" | dict "org" | dict "docker") $ }}
+{{/* .git */}}
+{{ $ = dict | dict "git" | merge $ }}
 {{/* .git.user */}}
-{{ $ = merge (default "SUSE CFCIBot" $.git.user | dict "user" | dict "git") $ }}
+{{ $ = merge (index $.git "user" | default "SUSE CFCIBot" | dict "user" | dict "git") $ }}
 {{/* .git.email */}}
-{{ $ = merge (default "cf-ci-bot@suse.de" $.git.email | dict "email" | dict "git") $ }}
+{{ $ = merge (index $.git "email" | default "cf-ci-bot@suse.de" | dict "email" | dict "git") $ }}
+{{/* .repos */}}
+{{ $ = dict | dict "repos" | merge $ }}
 {{/* .repos.trigger */}}
-{{ $ = merge (default true $.repos.trigger | dict "trigger" | dict "repos") $ }}
+{{ $ = merge (index $.repos "trigger" | default true | dict "trigger" | dict "repos") $ }}
 {{/* .repos.org */}}
-{{ $ = merge (default "SUSE" $.repos.org | dict "org" | dict "repos") $ }}
+{{ $ = merge (index $.repos "org" | default "SUSE" | dict "org" | dict "repos") $ }}
 {{/* .repos.<repo> */}}
 {{ range $repos }}
 {{ $ = merge (index $.repos . | default (printf "%s/eirini-%s" $.repos.org .) | dict . | dict "repos") $ }}
@@ -70,12 +76,14 @@
 {{ end }}
 
 groups:
+- name: build-base
+  jobs: [ build-base ]
 - name: logging
   jobs: [ loggregator-bridge ]
 - name: persi
   jobs: [ persi, persi-broker ]
 - name: ssh
-  jobs: [ ssh-extension, ssh-proxy ]
+  jobs: [ ssh, ssh-proxy ]
 
 resources:
 # source GitHub repositories

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -105,8 +105,8 @@
 {{ end }}
 
 groups:
-- name: chart
-  jobs: [ package-base, chart ]
+- name: package-base
+  jobs: [ package-base ]
 - name: logging
   jobs: [ loggregator-bridge ]
 - name: persi
@@ -123,14 +123,6 @@ resources:
     branch: master
     uri: https://github.com/{{ index $.repos . }}
 {{ end }}
-- name: github-release.chart
-  type: github-release
-  source:
-    owner: {{ $.repos.org }}
-    repository: eirinix-helm-release
-    access_token: {{ $.repos.token }}
-    release: false
-    pre_release: true
 
 # Docker image outputs
 {{ range $images }}
@@ -180,7 +172,7 @@ jobs:
 {{ template "build-image" (dict "repo" "eirini-ssh" "image" "ssh" | merge $) }}
 {{ template "build-image" (dict "repo" "eirinix-helm-release" "image" "ssh-proxy-setup" "docker-path" "images/ssh-proxy-setup") | merge $ }}
 
-# group chart
+# group package-base
 - name: package-base
   plan:
   - get: docker.base
@@ -210,61 +202,3 @@ jobs:
   - put: docker.package-base
     params:
       build: dockerfile
-- name: chart
-  plan:
-  - in_parallel:
-    {{- range $images }}
-    - get: s3.{{ . }}-version
-      trigger: {{ $.repos.trigger }}
-      passed: [ {{ . }} ]
-    {{- end }}
-    - get: docker.package-base
-    - get: git.eirinix-helm-release
-      trigger: {{ $.repos.trigger }}
-  - task: build
-    config:
-      platform: linux
-      inputs:
-      - name: git.eirinix-helm-release
-      {{- range $images }}
-      - name: s3.{{ . }}-version
-      {{- end }}
-      outputs:
-      - name: output
-      run:
-        dir: git.eirinix-helm-release
-        path: bin/package
-    image: docker.package-base
-    params:
-      VERSION_FILE: ../output/version.txt
-      COMMIT_HASH_FILE: ../output/commit.txt
-      OUTPUT_DIR: ../output/
-      OVERRIDES: |
-        {{- range $images }}
-        {{- if . | strings.HasSuffix "-setup" | not }}
-        {{ . }}:
-          image:
-            repository: {{ $.docker.repository }}
-            tag: <%= File.read('../s3.{{ . }}-version/version') %>
-          {{- if printf "%s-setup" . | has $images }}
-          setup-image:
-            repository: {{ $.docker.repository }}
-            tag: <%= File.read('../s3.{{ . }}-setup-version/version') %>
-          {{- end }}
-        {{- end }}
-        {{- end }}
-        ssh-proxy:
-          image:
-            repository: {{ $.docker.repository }}
-            tag: <%= File.read('../s3.ssh-version/version') %>
-          setup-image:
-            repository: {{ $.docker.repository }}
-            tag: <%= File.read('../s3.ssh-proxy-setup-version/version') %>
-  - put: github-release.chart
-    params:
-      name: output/version.txt
-      tag: output/version.txt
-      tag_prefix: v
-      commitish: output/commit.txt
-      globs: [ output/eirini-extensions-*.tgz ]
-      body: output/body.txt

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -1,0 +1,171 @@
+
+{{/* list of repositories and output images */}}
+
+{{ $repos := slice "loggregator-bridge" "persi" "persi-broker" "ssh" }}
+{{ $images := slice "loggregator-bridge" "persi" "persi-broker" "ssh" "ssh-proxy" }}
+
+{{/* configure default values */}}
+
+{{/* .docker.org */}}
+{{ $ = merge (default "cfcontainerization" $.docker.org | dict "org" | dict "docker") $ }}
+{{/* .git.user */}}
+{{ $ = merge (default "SUSE CFCIBot" $.git.user | dict "user" | dict "git") $ }}
+{{/* .git.email */}}
+{{ $ = merge (default "cf-ci-bot@suse.de" $.git.email | dict "email" | dict "git") $ }}
+{{/* .repos.trigger */}}
+{{ $ = merge (default true $.repos.trigger | dict "trigger" | dict "repos") $ }}
+{{/* .repos.org */}}
+{{ $ = merge (default "SUSE" $.repos.org | dict "org" | dict "repos") $ }}
+{{/* .repos.<repo> */}}
+{{ range $repos }}
+{{ $ = merge (index $.repos . | default (printf "%s/eirini-%s" $.repos.org .) | dict . | dict "repos") $ }}
+{{ end }}
+
+{{/* This template builds a go binary from source */}}
+{{/* Requires `.repo`, `.image`, and `.subdir` keys */}}
+{{ define "direct-build" }}
+- name: {{ $.image }}
+  plan:
+  - get: docker.build-base
+  - get: git.{{ $.repo }}
+    trigger: {{ $.repos.trigger }}
+    version: every
+  - task: build
+    config:
+      platform: linux
+      inputs:
+      - name: src
+      outputs:
+      - name: bin
+      caches:
+      - path: cache
+      run:
+        path: /bin/sh
+        args:
+        - -c
+        - >
+          set -o errexit -o nounset -o xtrace ;
+          export GOCACHE=$PWD/cache ;
+          OUTFILE=${PWD}/bin/{{ $.image }} ;
+          cd src ;
+          GO111MODULES=on go mod vendor ;
+          go build -o ${OUTFILE} ./{{ $.subdir }}/
+    image: docker.build-base
+    input_mapping:
+      src: git.{{ $.repo }}
+  - task: image
+    config:
+      platform: linux
+      inputs:
+      - name: bin
+      outputs:
+      - name: image
+      run:
+        path: /usr/bin/tar
+        args: [ cf, image/image.tar, -C, bin, {{ $.image }} ]
+    image: docker.build-base
+  - put: docker.{{ $.image }}
+    params:
+      import_file: image/image.tar
+{{ end }}
+
+groups:
+- name: logging
+  jobs: [ loggregator-bridge ]
+- name: persi
+  jobs: [ persi, persi-broker ]
+- name: ssh
+  jobs: [ ssh-extension, ssh-proxy ]
+
+resources:
+# source GitHub repositories
+{{ range $repos }}
+- name: git.{{ . }}
+  type: git
+  source:
+    branch: master
+    uri: https://github.com/{{ index $.repos . }}
+{{ end }}
+
+# Docker image outputs
+{{ range $images }}
+- name: docker.{{ . }}
+  type: docker-image
+  source:
+    repository: {{ $.docker.org }}/eirinix-{{ . }}
+    username:   ((docker-username))
+    password:   ((docker-password))
+    build_args:
+      user: {{ $.git.user }}
+      email: {{ $.git.email }}
+
+{{ end }}
+
+# Docker image for building images
+- name: docker.build-base
+  type: docker-image
+  source:
+    repository: {{ $.docker.org }}/eirinix-build-base
+    username:   ((docker-username))
+    password:   ((docker-password))
+
+jobs:
+
+# Job to construct docker.build-base
+- name: build-base
+  plan:
+  - task: dockerfile
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source: { repository: opensuse/leap }
+      outputs:
+      - name: out
+      run:
+        path: /bin/sh
+        args:
+        - -c
+        - echo "${DATA}" > out/Dockerfile
+      params:
+        DATA: |
+          FROM opensuse/leap
+          RUN true \
+            && zypper --non-interactive refresh \
+            && zypper --non-interactive install \
+              git-core \
+              bzr \
+              python-openssl \
+              'go >= 1.12' \
+              tar \
+            && zypper --non-interactive clean
+  - put: docker.build-base
+    params:
+      build: out
+
+{{ if has $images "loggregator-bridge" }}
+- name: loggregator-bridge
+  plan:
+  - get: git.loggregator-bridge
+    trigger: {{ $.repos.trigger }}
+    version: every
+  - put: docker.loggregator-bridge
+    params:
+      build: git.loggregator-bridge
+{{ end }}
+
+{{ if has $images "persi" }}
+{{ template "direct-build" (dict "repo" "persi" "subdir" "cmd/eirini-ext" "image" "persi" | merge $) }}
+{{ end }}
+
+{{ if has $images "persi-broker" }}
+{{ template "direct-build" (dict "repo" "persi-broker" "subdir" "cmd/broker" "image" "persi-broker" | merge $) }}
+{{ end }}
+
+{{ if has $images "ssh" }}
+{{ template "direct-build" (dict "repo" "ssh" "subdir" "cmd/extension" "image" "ssh" | merge $) }}
+{{ end }}
+
+{{ if has $images "ssh-proxy" }}
+{{ template "direct-build" (dict "repo" "ssh" "subdir" "cmd/ssh-proxy" "image" "ssh-proxy" | merge $) }}
+{{ end }}

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -1,35 +1,43 @@
 
-{{/* list of repositories and output images */}}
+{{- /* list of repositories and output images */ -}}
 
-{{ $repos := slice "eirini-loggregator-bridge" "eirini-persi" "eirini-persi-broker" "eirini-ssh" "eirinix-helm-release" }}
-{{ $images := slice "loggregator-bridge" "persi" "persi-broker" "persi-broker-setup" "ssh" "ssh-proxy-setup" }}
+{{- $repos := slice "eirini-loggregator-bridge" "eirini-persi" "eirini-persi-broker" "eirini-ssh" "eirinix-helm-release" }}
+{{- $images := slice "loggregator-bridge" "persi" "persi-broker" "persi-broker-setup" "ssh" "ssh-proxy-setup" }}
 
-{{/* configure default values */}}
+{{- /* configure default values */ -}}
 
-{{/* $.docker */}}
-{{ $ = dict | dict "docker" | merge $ }}
-{{/* .docker.org */}}
-{{ $ = merge (index $.docker "org" | default "splatform" | dict "org" | dict "docker") $ }}
-{{/* .git */}}
-{{ $ = dict | dict "git" | merge $ }}
-{{/* .git.user */}}
-{{ $ = merge (index $.git "user" | default "SUSE CFCIBot" | dict "user" | dict "git") $ }}
-{{/* .git.email */}}
-{{ $ = merge (index $.git "email" | default "cf-ci-bot@suse.de" | dict "email" | dict "git") $ }}
-{{/* .repos */}}
-{{ $ = dict | dict "repos" | merge $ }}
-{{/* .repos.trigger */}}
-{{ $ = merge (index $.repos "trigger" | default true | dict "trigger" | dict "repos") $ }}
-{{/* .repos.org */}}
-{{ $ = merge (index $.repos "org" | default "SUSE" | dict "org" | dict "repos") $ }}
-{{/* .repos.<repo> */}}
-{{ range $repos }}
-{{ $ = merge (index $.repos . | default (printf "%s/%s" $.repos.org .) | dict . | dict "repos") $ }}
-{{ end }}
+{{- /* $.docker */ -}}
+{{- $ = dict | dict "docker" | merge $ -}}
+{{- /* .docker.org */ -}}
+{{- $ = merge (index $.docker "org" | default "splatform" | dict "org" | dict "docker") $ -}}
+{{- /* .git */ -}}
+{{- $ = dict | dict "git" | merge $ -}}
+{{- /* .git.user */ -}}
+{{- $ = merge (index $.git "user" | default "SUSE CFCIBot" | dict "user" | dict "git") $ -}}
+{{- /* .git.email */ -}}
+{{- $ = merge (index $.git "email" | default "cf-ci-bot@suse.de" | dict "email" | dict "git") $ -}}
+{{- /* .repos */ -}}
+{{- $ = dict | dict "repos" | merge $ -}}
+{{- /* .repos.trigger */ -}}
+{{- $ = merge (index $.repos "trigger" | default true | dict "trigger" | dict "repos") $ -}}
+{{- /* .repos.org */ -}}
+{{- $ = merge (index $.repos "org" | default "SUSE" | dict "org" | dict "repos") $ -}}
+{{- /* .repos.<repo> */ -}}
+{{- range $repos -}}
+{{- $ = merge (index $.repos . | default (printf "%s/%s" $.repos.org .) | dict . | dict "repos") $ -}}
+{{- end -}}
+{{- /* $.s3 */ -}}
+{{- $ = dict | dict "s3" | merge $ -}}
+{{- /* $.s3.bucket */ -}}
+{{- $ = merge (index $.s3 "bucket" | default "eirini-suse" | dict "bucket" | dict "s3") $ -}}
+{{- /* $.s3.prefix */ -}}
+{{- $ = merge (index $.s3 "prefix" | default "" | dict "prefix" | dict "s3") $ -}}
+{{- /* $.s3.region_name */ -}}
+{{- $ = merge (index $.s3 "region_name" | default "us-east-1" | dict "region_name" | dict "s3") $ -}}
 
-{{/* This template builds a go binary from source */}}
-{{/* Requires `.repo`, `.image`, and `.subdir` keys */}}
-{{/* Optionally, `.docker-path` can be used to locate the Dockerfile. */}}
+{{- /* This template builds a go binary from source */ -}}
+{{- /* Requires `.repo`, `.image`, and `.subdir` keys */ -}}
+{{- /* Optionally, `.docker-path` can be used to locate the Dockerfile. */ -}}
 {{ define "build-image" }}
 - name: {{ $.image }}
   plan:
@@ -63,18 +71,24 @@
               . bin/include/versioning ;
               echo $VERSION_TAG ;
             else
-              git describe --tags --long --always ;
+              git describe --tags --long || \
+                printf "v0.0.0-g%s" "$(git describe --always)"
             fi
           ) > tag/tag.txt ;
-          cat tag/tag.txt ;
-  - put: docker.{{ $.image }}
-    params:
-      build: git.{{ $.repo }}/{{ index . "docker-path" | default "" }}
-      build_args:
-        USER: {{ $.git.user }}
-        EMAIL: {{ $.git.email }}
-        # BASE_IMAGE: scratch # FIXME: images are missing /tmp folder, which makes extensions to crash
-      tag_file: tag/tag.txt
+          cp tag/tag.txt "tag/image-{{ $.image }}-tag-$(cat tag/tag.txt).txt"
+  - in_parallel:
+    - put: docker.{{ $.image }}
+      params:
+        build: git.{{ $.repo }}/{{ index . "docker-path" | default "" }}
+        build_args:
+          USER: {{ $.git.user }}
+          EMAIL: {{ $.git.email }}
+          # BASE_IMAGE: scratch # FIXME: images are missing /tmp folder, which makes extensions to crash
+        tag_file: tag/tag.txt
+        tag_as_latest: true
+    - put: s3.{{ $.image }}-version
+      params:
+        file: tag/image-{{ $.image }}-tag-*.txt
 {{ end }}
 
 groups:
@@ -105,6 +119,16 @@ resources:
     repository: {{ $.docker.org }}/eirinix-{{ . }}
     username:   ((docker-username))
     password:   ((docker-password))
+- name: s3.{{ . }}-version
+  type: s3
+  source:
+    bucket: {{ $.s3.bucket }}
+    {{- range keys $.s3 }}
+    {{- if has (slice "bucket" "prefix") . | not }}
+    {{ . }}: {{ index $.s3 . }}
+    {{- end }}
+    {{- end }}
+    regexp: {{ $.s3.prefix | default ""  }}image-{{ . }}-tag-(.*).txt
 {{ end }}
 - name: docker.base
   type: docker-image
@@ -117,6 +141,18 @@ resources:
     repository: {{ $.docker.org }}/eirinix-package-base
     username:   ((docker-username))
     password:   ((docker-password))
+
+# S3 bucket for chart
+- name: s3.chart
+  type: s3
+  source:
+    bucket: {{ $.s3.bucket }}
+    {{- range keys $.s3 }}
+    {{- if has (slice "bucket" "prefix") . | not }}
+    {{ . }}: {{ index $.s3 . }}
+    {{- end }}
+    {{- end }}
+    regexp: {{ $.s3.prefix | default "" }}eirini-extensions-(.*).tgz
 
 jobs:
 # group logging
@@ -151,8 +187,9 @@ jobs:
           FROM opensuse/leap:15.2
           RUN true \
             && zypper --non-interactive install \
+              git-core \
               helm \
-              python3-yq \
+              ruby \
             && zypper --non-interactive clean
     image: docker.base
   - put: docker.package-base
@@ -162,9 +199,8 @@ jobs:
   plan:
   - in_parallel:
     {{- range $images }}
-    - get: docker.{{ . }}
-      params:
-        skip_download: true
+    - get: s3.{{ . }}-version
+      trigger: {{ $.repos.trigger }}
     {{- end }}
     - get: docker.package-base
     - get: git.eirinix-helm-release
@@ -174,17 +210,22 @@ jobs:
       platform: linux
       inputs:
       - name: git.eirinix-helm-release
+      {{- range $images }}
+      - name: s3.{{ . }}-version
+      {{- end }}
       outputs:
       - name: output
       run:
-        path: /bin/sh
+        dir: git.eirinix-helm-release
+        path: bin/package
         args:
-        - -c
-        - >
-          helm package git.eirinix-helm-release/chart
-          --destination output
+        - --destination=../output
     image: docker.package-base
     params:
       {{- range $images }}
-      TAG_FILE_{{ . | strings.SnakeCase | toUpper }}: docker.{{ . }}/tag
+      TAG_FILE_{{ . | strings.SnakeCase | toUpper }}: ../s3.{{ . }}-version/version
       {{- end }}
+  - put: s3.chart
+    params:
+      file: output/eirini-extensions-*.tgz
+      acl: public-read

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -1,8 +1,8 @@
 
 {{/* list of repositories and output images */}}
 
-{{ $repos := slice "loggregator-bridge" "persi" "persi-broker" "ssh" }}
-{{ $images := slice "loggregator-bridge" "persi" "persi-broker" "ssh" }}
+{{ $repos := slice "eirini-loggregator-bridge" "eirini-persi" "eirini-persi-broker" "eirini-ssh" "eirinix-helm-release" }}
+{{ $images := slice "loggregator-bridge" "persi" "persi-broker" "persi-broker-setup" "ssh" "ssh-proxy-setup" }}
 
 {{/* configure default values */}}
 
@@ -24,11 +24,12 @@
 {{ $ = merge (index $.repos "org" | default "SUSE" | dict "org" | dict "repos") $ }}
 {{/* .repos.<repo> */}}
 {{ range $repos }}
-{{ $ = merge (index $.repos . | default (printf "%s/eirini-%s" $.repos.org .) | dict . | dict "repos") $ }}
+{{ $ = merge (index $.repos . | default (printf "%s/%s" $.repos.org .) | dict . | dict "repos") $ }}
 {{ end }}
 
 {{/* This template builds a go binary from source */}}
 {{/* Requires `.repo`, `.image`, and `.subdir` keys */}}
+{{/* Optionally, `.docker-path` can be used to locate the Dockerfile. */}}
 {{ define "build-image" }}
 - name: {{ $.image }}
   plan:
@@ -40,26 +41,35 @@
       platform: linux
       image_resource:
         type: registry-image
-        source: { repository: opensuse/leap }
+        source: { repository: golang }
       inputs:
       - name: git.{{ $.repo }}
         path: src
       outputs:
       - name: tag
+      params:
+        GIT_AUTHOR_NAME: {{ $.git.user }}
+        GIT_AUTHOR_EMAIL: {{ $.git.email }}
       run:
         path: /bin/sh
         args:
         - -c
         - >
-          export XTRACE=on ;
+          git config --global user.name  $GIT_AUTHOR_NAME ;
+          git config --global user.email $GIT_AUTHOR_EMAIL ;
           (
             cd src ;
-            bin/include/versioning
-          ) > tag/tag.txt
-
+            if [ -r bin/include/versioning ] ; then
+              . bin/include/versioning ;
+              echo $VERSION_TAG ;
+            else
+              git describe --tags --long --always ;
+            fi
+          ) > tag/tag.txt ;
+          cat tag/tag.txt ;
   - put: docker.{{ $.image }}
     params:
-      build: git.{{ $.repo }}/
+      build: git.{{ $.repo }}/{{ index . "docker-path" | default "" }}
       build_args:
         USER: {{ $.git.user }}
         EMAIL: {{ $.git.email }}
@@ -68,12 +78,14 @@
 {{ end }}
 
 groups:
+- name: chart
+  jobs: [ package-base, chart ]
 - name: logging
   jobs: [ loggregator-bridge ]
 - name: persi
-  jobs: [ persi, persi-broker ]
+  jobs: [ persi, persi-broker, persi-broker-setup ]
 - name: ssh
-  jobs: [ ssh ]
+  jobs: [ ssh, ssh-proxy-setup ]
 
 resources:
 # source GitHub repositories
@@ -94,20 +106,85 @@ resources:
     username:   ((docker-username))
     password:   ((docker-password))
 {{ end }}
+- name: docker.base
+  type: docker-image
+  source:
+    repository: opensuse/leap
+    tag:        15.2
+- name: docker.package-base
+  type: docker-image
+  source:
+    repository: {{ $.docker.org }}/eirinix-package-base
+    username:   ((docker-username))
+    password:   ((docker-password))
 
 jobs:
-{{ if has $images "loggregator-bridge" }}
-{{ template "build-image" (dict "repo" "loggregator-bridge" "image" "loggregator-bridge" | merge $) }}
-{{ end }}
+# group logging
+{{ template "build-image" (dict "repo" "eirini-loggregator-bridge" "image" "loggregator-bridge" | merge $) }}
 
-{{ if has $images "persi" }}
-{{ template "build-image" (dict "repo" "persi" "image" "persi" | merge $) }}
-{{ end }}
+# group persi
+{{ template "build-image" (dict "repo" "eirini-persi" "image" "persi" | merge $) }}
+{{ template "build-image" (dict "repo" "eirini-persi-broker" "image" "persi-broker" | merge $) }}
+{{ template "build-image" (dict "repo" "eirinix-helm-release" "image" "persi-broker-setup" "docker-path" "images/persi-broker-setup") | merge $ }}
 
-{{ if has $images "persi-broker" }}
-{{ template "build-image" (dict "repo" "persi-broker" "image" "persi-broker" | merge $) }}
-{{ end }}
+# group ssh
+{{ template "build-image" (dict "repo" "eirini-ssh" "image" "ssh" | merge $) }}
+{{ template "build-image" (dict "repo" "eirinix-helm-release" "image" "ssh-proxy-setup" "docker-path" "images/ssh-proxy-setup") | merge $ }}
 
-{{ if has $images "ssh" }}
-{{ template "build-image" (dict "repo" "ssh" "image" "ssh" | merge $) }}
-{{ end }}
+# group chart
+- name: package-base
+  plan:
+  - get: docker.base
+    trigger: {{ $.repos.trigger }}
+  - task: dockerfile
+    config:
+      platform: linux
+      outputs:
+      - name: dockerfile
+      run:
+        path: /bin/sh
+        args:
+        - -c
+        - echo "${CONTENTS}" > dockerfile/Dockerfile
+      params:
+        CONTENTS: |
+          FROM opensuse/leap:15.2
+          RUN true \
+            && zypper --non-interactive install \
+              helm \
+              python3-yq \
+            && zypper --non-interactive clean
+    image: docker.base
+  - put: docker.package-base
+    params:
+      build: dockerfile
+- name: chart
+  plan:
+  - in_parallel:
+    {{- range $images }}
+    - get: docker.{{ . }}
+      params:
+        skip_download: true
+    {{- end }}
+    - get: docker.package-base
+    - get: git.eirinix-helm-release
+      trigger: {{ $.repos.trigger }}
+  - task: build
+    config:
+      platform: linux
+      inputs:
+      - name: git.eirinix-helm-release
+      outputs:
+      - name: output
+      run:
+        path: /bin/sh
+        args:
+        - -c
+        - >
+          helm package git.eirinix-helm-release/chart
+          --destination output
+    image: docker.package-base
+    params:
+      {{- range $images }}
+      TAG_FILE_{{ . | strings.SnakeCase | toUpper }}: docker.{{ . }}/tag
+      {{- end }}

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -10,6 +10,10 @@
 {{- $ = dict | dict "docker" | merge $ -}}
 {{- /* .docker.repository */ -}}
 {{- $ = merge (index $.docker "repository" | default "splatform" | dict "repository" | dict "docker") $ -}}
+{{- /* .docker.username */ -}}
+{{- $ = merge (index $.docker "username" | default "((docker-username))" | dict "username" | dict "docker") $ -}}
+{{- /* .docker.password */ -}}
+{{- $ = merge (index $.docker "password" | default "((docker-password))" | dict "password" | dict "docker") $ -}}
 {{- /* .git */ -}}
 {{- $ = dict | dict "git" | merge $ -}}
 {{- /* .git.user */ -}}
@@ -134,8 +138,8 @@ resources:
   type: docker-image
   source:
     repository: {{ $.docker.repository }}/eirinix-{{ . }}
-    username:   ((docker-username))
-    password:   ((docker-password))
+    username:   {{ $.docker.username }}
+    password:   {{ $.docker.password }}
 {{ end }}
 - name: docker.base
   type: docker-image
@@ -146,8 +150,8 @@ resources:
   type: docker-image
   source:
     repository: {{ $.docker.repository }}/eirinix-package-base
-    username:   ((docker-username))
-    password:   ((docker-password))
+    username:   {{ $.docker.username }}
+    password:   {{ $.docker.password }}
 
 # S3 resources
 {{ range $images }}

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -185,8 +185,10 @@ jobs:
       params:
         CONTENTS: |
           FROM opensuse/leap:15.2
+          # coreutils required for sha256sum / date
           RUN true \
             && zypper --non-interactive install \
+              coreutils \
               git-core \
               helm \
               ruby \
@@ -201,6 +203,7 @@ jobs:
     {{- range $images }}
     - get: s3.{{ . }}-version
       trigger: {{ $.repos.trigger }}
+      passed: [ {{ . }} ]
     {{- end }}
     - get: docker.package-base
     - get: git.eirinix-helm-release


### PR DESCRIPTION
Move the concourse pipeline from the archived read-only https://github.com/cloudfoundry-incubator/eirinix-helm-release to this repo.

Moved the code with `git filter-branch`, `git update-index` to preseve history and allow a clean merge.


The pipeline builds the SUSE Eirini extensions docker images, which keeps being needed.

It also has a job to create the Helm chart and publish it to github, which has been removed in https://github.com/cloudfoundry-incubator/eirinix/commit/998a0a74c0a1380ee459008c2bd234a7fae154df.
Example of flown pipeline in https://concourse.suse.dev/teams/main/pipelines/vic-eirinix. 